### PR TITLE
Refactor Step Definitions

### DIFF
--- a/src/main/java/Config/Config.java
+++ b/src/main/java/Config/Config.java
@@ -21,6 +21,7 @@ public class Config {
     routes.add(new Route(OPTIONS, "/method_options2", new OPTIONS2Handler()));
     routes.add(new Route(GET, "/not-found", new NotFoundHandler()));
     routes.add(new Route(HEAD, "/", new HEAD200Handler()));
+    routes.add(new Route(HEAD, "/foobar", new HEAD404Handler()));
     return routes;
   }
 

--- a/src/main/java/Config/Config.java
+++ b/src/main/java/Config/Config.java
@@ -20,6 +20,7 @@ public class Config {
     routes.add(new Route(OPTIONS, "/method_options", new OPTIONSHandler()));
     routes.add(new Route(OPTIONS, "/method_options2", new OPTIONS2Handler()));
     routes.add(new Route(GET, "/not-found", new NotFoundHandler()));
+    routes.add(new Route(HEAD, "/", new HEAD200Handler()));
     return routes;
   }
 

--- a/src/main/java/Config/Method.java
+++ b/src/main/java/Config/Method.java
@@ -4,7 +4,9 @@ public enum Method {
   GET,
   POST, 
   PUT,
-  OPTIONS;
+  OPTIONS,
+  HEAD;
+
 
   public static Method toMethod(String stringMethod) {
     switch (stringMethod) {
@@ -16,6 +18,8 @@ public enum Method {
         return OPTIONS;
       case "PUT":
         return PUT;
+      case "HEAD":
+        return HEAD;
       default:
         throw new Error();
     }

--- a/src/main/java/Config/Method.java
+++ b/src/main/java/Config/Method.java
@@ -7,7 +7,6 @@ public enum Method {
   OPTIONS,
   HEAD;
 
-
   public static Method toMethod(String stringMethod) {
     switch (stringMethod) {
       case "GET":

--- a/src/main/java/Controller/Handler/HEAD200Handler.java
+++ b/src/main/java/Controller/Handler/HEAD200Handler.java
@@ -1,0 +1,12 @@
+package Controller.Handler;
+
+import Request.Request;
+import Response.Response;
+
+public class HEAD200Handler extends Handler {
+  public Response handle(Request request) {
+    return new Response.Builder()
+      .setStatusCode(200)
+      .build();
+  }
+}

--- a/src/main/java/Controller/Handler/HEAD404Handler.java
+++ b/src/main/java/Controller/Handler/HEAD404Handler.java
@@ -1,0 +1,12 @@
+package Controller.Handler;
+
+import Request.Request;
+import Response.Response;
+
+public class HEAD404Handler extends Handler {
+  public Response handle(Request request) {
+    return new Response.Builder()
+      .setStatusCode(404)
+      .build();
+  }
+}

--- a/src/test/java/Config/Routes/RouteTest.java
+++ b/src/test/java/Config/Routes/RouteTest.java
@@ -25,18 +25,6 @@ public class RouteTest {
   }
 
   @Test
-  public void testGETHandlerPath() {
-    Route route = new Route(GET, "/", new GETHandler());
-    assertEquals(((GETHandler) route.handler).path, "/");
-  }
-
-  @Test
-  public void testGETHandlerMethod() {
-    Route route = new Route(GET, "/", new GETHandler());
-    assertEquals(((GETHandler) route.handler).method, GET);
-  }
-
-  @Test
   public void testGETHandlerResponseStatusCode() {
     Route route = new Route(GET, "/", new GETHandler());
     String requestString = "GET / HTTP/1.1" + CRLF +
@@ -75,18 +63,6 @@ public class RouteTest {
   public void testPOSTPath() {
     Route route = new Route(POST, "/echo", new POSTEchoHandler());
     assertEquals("/echo", route.path);
-  }
-
-  @Test
-  public void testPOSTEchoHandlerPath() {
-    Route route = new Route(POST, "/echo", new POSTEchoHandler());
-    assertEquals("/echo", ((POSTEchoHandler) route.handler).path);
-  }
-
-  @Test
-  public void testPOSTEchoHandlerMethod() {
-    Route route = new Route(POST, "/echo", new POSTEchoHandler());
-    assertEquals(POST, ((POSTEchoHandler) route.handler).method);
   }
 
   @Test

--- a/src/test/java/Controller/Handler/GETEchoHandlerTest.java
+++ b/src/test/java/Controller/Handler/GETEchoHandlerTest.java
@@ -3,23 +3,10 @@ package Controller.Handler;
 import Request.Request;
 import org.junit.Test;
 
-import static Config.Method.GET;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class GETEchoHandlerTest {
   private String CRLF = "\r\n";
-
-  @Test
-  public void testGETEchoHandlerPath() {
-    Handler handler = new GETEchoHandler();
-    assertEquals("/echo", ((GETEchoHandler) handler).path);
-  }
-
-  @Test
-  public void testGETEchoHandlerMethod() {
-    Handler handler = new GETEchoHandler();
-    assertEquals(GET, ((GETEchoHandler) handler).method);
-  }
 
   @Test
   public void handlerReturnResponseBody() {

--- a/src/test/java/Controller/Handler/GETHandlerTest.java
+++ b/src/test/java/Controller/Handler/GETHandlerTest.java
@@ -2,24 +2,11 @@ package Controller.Handler;
 
 import Request.Request;
 import org.junit.Test;
-import static Config.Method.GET;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class GETHandlerTest {
   private String CRLF = "\r\n";
-
-  @Test
-  public void testGETHandlerPath() {
-    Handler handler = new GETHandler();
-    assertEquals("/", ((GETHandler) handler).path);
-  }
-
-  @Test
-  public void testGETHandlerMethod() {
-    Handler handler = new GETHandler();
-    assertEquals(GET, ((GETHandler) handler).method);
-  }
 
   @Test
   public void handlerReturnResponseBody() {

--- a/src/test/java/Controller/Handler/POSTEchoHandlerTest.java
+++ b/src/test/java/Controller/Handler/POSTEchoHandlerTest.java
@@ -3,24 +3,10 @@ package Controller.Handler;
 import Request.Request;
 import org.junit.Test;
 
-import static Config.Method.GET;
-import static Config.Method.POST;
 import static org.junit.Assert.assertEquals;
 
 public class POSTEchoHandlerTest {
   private String CRLF = "\r\n";
-
-  @Test
-  public void testPOSTEchoHandlerPath() {
-    Handler handler = new POSTEchoHandler();
-    assertEquals("/echo", ((POSTEchoHandler) handler).path);
-  }
-
-  @Test
-  public void testPOSTEchoHandlerMethod() {
-    Handler handler = new POSTEchoHandler();
-    assertEquals(POST, ((POSTEchoHandler) handler).method);
-  }
 
   @Test
   public void handlerReturnResponseBody() {

--- a/src/test/java/HttpClient/HTTPClient.java
+++ b/src/test/java/HttpClient/HTTPClient.java
@@ -1,0 +1,89 @@
+package HttpClient;
+
+import org.apache.http.*;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.*;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static gradle.cucumber.StepDefinitionsHelper.parseFormData;
+
+public class HTTPClient {
+  private final int port;
+  private final String host;
+  private final CloseableHttpClient client;
+  private CloseableHttpResponse response;
+
+  public HTTPClient(int port, String host) {
+    this.port = port;
+    this.host = host;
+    this.client = HttpClients.createDefault();
+  }
+
+  private URI uri(String path) throws URISyntaxException {
+    return new URIBuilder()
+      .setScheme("http")
+      .setHost(host)
+      .setPort(port)
+      .setPath(path)
+      .build();
+  }
+
+  public CloseableHttpResponse get(String path) throws IOException, URISyntaxException {
+    HttpGet httpGet = new HttpGet(uri(path));
+    return response = client.execute(httpGet);
+  }
+
+  public CloseableHttpResponse post(String body, String path) throws IOException, URISyntaxException {
+    HttpPost httpPost = new HttpPost(uri(path));
+    httpPost.setEntity(new StringEntity(body));
+    return response = client.execute(httpPost);
+  }
+
+  public CloseableHttpResponse options(String path) throws IOException, URISyntaxException {
+    HttpOptions httpOptions = new HttpOptions(uri(path));
+    return response = client.execute(httpOptions);
+  }
+
+  public CloseableHttpResponse put(String body, String path) throws IOException, URISyntaxException {
+    HttpPut httpPut = new HttpPut(uri(path));
+    List<NameValuePair> formParams = new ArrayList<>();
+    formParams.add(new BasicNameValuePair(parseFormData(body)[0], parseFormData(body)[1]));
+    UrlEncodedFormEntity entity = new UrlEncodedFormEntity(formParams, Consts.UTF_8);
+    httpPut.setEntity(entity);
+    return response = client.execute(httpPut);
+  }
+
+  public String getResponseBody() throws IOException {
+    return new BasicResponseHandler().handleResponse(response);
+  }
+
+  public int getResponseStatusCode() {
+    return response.getStatusLine().getStatusCode();
+  }
+
+  public Set<String> getHeaders(String headerName) {
+    HeaderIterator it = response.headerIterator(headerName);
+    Set<String> headerValues = new HashSet<>();
+    while (it.hasNext()) {
+      Header header = it.nextHeader();
+      HeaderElement[] elements = header.getElements();
+      for (HeaderElement element : elements) {
+        headerValues.add(element.getName());
+      }
+    }
+    return headerValues;
+  }
+}

--- a/src/test/java/gradle/cucumber/EchoSteps.java
+++ b/src/test/java/gradle/cucumber/EchoSteps.java
@@ -161,6 +161,7 @@ public class EchoSteps {
     response = httpclient.execute(httpGet);
   }
 
+
   @When("^I request \"HEAD\" \"([^\"]*)\"$")
   public void iRequestHead(String path) throws Throwable {
     httpclient = HttpClients.createDefault();

--- a/src/test/java/gradle/cucumber/EchoSteps.java
+++ b/src/test/java/gradle/cucumber/EchoSteps.java
@@ -14,8 +14,6 @@ import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.net.URI;
@@ -71,6 +69,18 @@ public class EchoSteps {
     response = httpclient.execute(httpGet);
   }
 
+  @Then("^the response status should be (\\d+)$")
+  public void theResponseStatusShouldBe(int status) {
+    assertEquals(status, response.getStatusLine().getStatusCode());
+  }
+
+  @And("^the response body should be \"([^\"]*)\"$")
+  public void theResponseBodyShouldBe(String responseBody) throws IOException {
+    String responseBody1;
+    responseBody1 = new BasicResponseHandler().handleResponse(response);
+    assertEquals(responseBody, responseBody1);
+  }
+
   @When("^I \"PUT\" \"([^\"]*)\" to \"([^\"]*)\"$")
   public void iPutTo(String body, String path) throws Throwable {
     httpclient = HttpClients.createDefault();
@@ -105,35 +115,23 @@ public class EchoSteps {
       .setPort(DEFAULT_PORT)
       .setPath(path)
       .build();
-      HttpOptions httpOptions = new HttpOptions(uri);
+    HttpOptions httpOptions = new HttpOptions(uri);
     response = httpclient.execute(httpOptions);
   }
 
-  @Then("^the response status should be (\\d+)$")
-  public void theResponseStatusShouldBe(int status) {
-    assertEquals(status, response.getStatusLine().getStatusCode());
-  }
-  @Rule
-  public ExpectedException exceptionRule = ExpectedException.none();
-
-
   @And("the response body should be empty")
-  public void theResponseBodyShouldBeEmpty()  throws Throwable {
+  public void theResponseBodyShouldBeEmpty() throws Throwable {
     String responseBody;
     try {
       responseBody = new BasicResponseHandler().handleResponse(response);
+      if (responseBody == null) {
+        responseBody = "";
+      }
     } catch (HttpResponseException e) {
       System.err.println(e.getMessage());
       responseBody = e.getMessage();
     }
     assertEquals("", responseBody);
-  }
-
-  @And("^the response body should be \"([^\"]*)\"$")
-  public void theResponseBodyShouldBe(String responseBody) throws IOException {
-    String responseBody1;
-    responseBody1 = new BasicResponseHandler().handleResponse(response);
-    assertEquals(responseBody, responseBody1);
   }
 
   @And("^the response header should include \"Allow\" \"([^\"]*)\"$")
@@ -161,5 +159,18 @@ public class EchoSteps {
       .build();
     httpGet = new HttpGet(uri);
     response = httpclient.execute(httpGet);
+  }
+
+  @When("^I request \"HEAD\" \"([^\"]*)\"$")
+  public void iRequestHead(String path) throws Throwable {
+    httpclient = HttpClients.createDefault();
+    URI uri = new URIBuilder()
+      .setScheme("http")
+      .setHost(HOST)
+      .setPort(DEFAULT_PORT)
+      .setPath(path)
+      .build();
+    HttpHead httpHead = new HttpHead(uri);
+    response = httpclient.execute(httpHead);
   }
 }

--- a/src/test/java/gradle/cucumber/HTTPClientStepDefinitions.java
+++ b/src/test/java/gradle/cucumber/HTTPClientStepDefinitions.java
@@ -1,0 +1,84 @@
+package gradle.cucumber;
+
+import HttpClient.HTTPClient;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.And;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HTTPClientStepDefinitions {
+  private static String HOST = "127.0.0.1";
+  private HTTPClient client;
+
+  @Before
+  public void connectClient() {
+    int DEFAULT_PORT = 3000;
+    client = new HTTPClient(DEFAULT_PORT, HOST);
+  }
+
+  @Given("the server is running")
+  public void serverIsRunning() {
+  }
+
+  @And("^I request \"GET\" \"([^\"]*)\" on port \"([^\"]*)\"$")
+  public void iRequestOnPort(String path, String port) throws Throwable {
+    client = new HTTPClient(Integer.parseInt(port) , HOST);
+    client.get(path);
+  }
+
+  @When("^I request \"GET\" \"([^\"]*)\"$")
+  public void iRequest(String path) throws Throwable {
+    client.get(path);
+  }
+
+  @When("^I \"POST\" \"([^\"]*)\" to \"([^\"]*)\"$")
+  public void iPostTo(String body, String path) throws Throwable {
+    client.post(body, path);
+  }
+
+  @When("^I \"PUT\" \"([^\"]*)\" to \"([^\"]*)\"$")
+  public void iPutTo(String body, String path) throws Throwable {
+    client.put(body, path);
+  }
+
+  @When("^I request \"OPTIONS\" \"([^\"]*)\"$")
+  public void iRequestOptions(String path) throws Throwable {
+    client.options(path);
+  }
+
+  @Then("^the response status should be (\\d+)$")
+  public void theResponseStatusShouldBe(int status) {
+    assertEquals(status, client.getResponseStatusCode());
+  }
+
+  @And("^the response body should be \"([^\"]*)\"$")
+  public void theResponseBodyShouldBe(String responseBody) throws IOException {
+    assertEquals(responseBody, client.getResponseBody());
+  }
+
+  @And("the response body should be empty")
+  public void the_response_body_should_be_empty() throws IOException {
+    assertEquals("", client.getResponseBody());
+  }
+
+  @Given("^I am in a console shell$")
+  public void iAmInAConsoleShell() {
+  }
+
+  @When("^I start the server with the option \"([^\"]*)\"$")
+  public void iStartTheServerWithTheOption(String option) throws Throwable {
+    Runtime.getRuntime().exec("javac -cp src/main/java/StartServer.java");
+    Runtime.getRuntime().exec("java -cp src/main/java StartServer " + option);
+  }
+
+  @And("^the response header should include \"([^\"]*)\" \"([^\"]*)\"$")
+  public void theResponseHeaderShouldInclude(String header, String option) {
+    assertTrue(client.getHeaders(header).contains(option));
+  }
+}

--- a/src/test/resources/gradle/cucumber/features/head200.feature
+++ b/src/test/resources/gradle/cucumber/features/head200.feature
@@ -1,0 +1,6 @@
+Feature: HEAD /
+  Scenario: Server responds to HEAD request with 200
+    Given the server is running
+    When I request "HEAD" "/"
+    Then the response status should be 200
+    And the response body should be empty

--- a/src/test/resources/gradle/cucumber/features/head404.feature
+++ b/src/test/resources/gradle/cucumber/features/head404.feature
@@ -1,0 +1,6 @@
+Feature: HEAD /foobar
+  Scenario: Server responds to HEAD /foobar with 404
+    Given the server is running
+    When I request "HEAD" "/foobar"
+    Then the response status should be 404
+    And the response body should be empty


### PR DESCRIPTION
- Extract out the HTTP CLient library to its own class, making the Step Definitions more readable
- Remove repetitions such as the URI builder
- Rename the Step Definitions to reflect to content (Previously was called 'EchoSteps')